### PR TITLE
Change return type to Promise<any> for closeFunc

### DIFF
--- a/src/comp/drawer.md
+++ b/src/comp/drawer.md
@@ -182,7 +182,7 @@ props 内容可以见下方
 | isDetail       | `boolean`             | false  | -      | 是否为详情模式                       |
 | loading        | `boolean`             | false  | -      | loading 状态                         |
 | showDetailBack | `boolean`             | true   | -      | isDetail=true 状态下是否显示返回按钮 |
-| closeFunc      | `() => Promise<void>` | -      | -      | 自定义关闭函数                       |
+| closeFunc      | `() => Promise<any>` | -      | -      | 自定义关闭函数                       |
 
 ## Events
 


### PR DESCRIPTION
在 DrawerProps 定义中，closeFunc 方法的返回值为 Promise<any>：

```js
export interface DrawerProps extends DrawerFooterProps {
  isDetail?: boolean;
  loading?: boolean;
  showDetailBack?: boolean;
  visible?: boolean;
  /**
   * Built-in ScrollContainer component configuration
   * @type ScrollContainerOptions
   */
  scrollOptions?: ScrollContainerOptions;
  closeFunc?: () => Promise<any>
  ...
```

实际使用如下：

```js
      // Cancel event
      async function onClose(e: Recordable) {
        const { closeFunc } = unref(getProps);
        emit('close', e);
        if (closeFunc && isFunction(closeFunc)) {
          const res = await closeFunc();
          visibleRef.value = !res;
          return;
        }
        visibleRef.value = false;
      }
```

这里会利用返回值来设置 visible 的状态。